### PR TITLE
🐛 Fix build: bump stale Debian package pins

### DIFF
--- a/vaultwarden/Dockerfile
+++ b/vaultwarden/Dockerfile
@@ -24,8 +24,8 @@ RUN \
     \
     && apt-get install -y --no-install-recommends \
         libmariadb-dev-compat=1:11.8.6-0+deb13u1 \
-        libpq5=17.9-0+deb13u1 \
-        nginx=1.26.3-3+deb13u2 \
+        libpq5=17.10-0+deb13u1 \
+        nginx=1.26.3-3+deb13u7 \
         sqlite3=3.46.1-7+deb13u1 \
     && apt-get clean \
     && rm -f -r \


### PR DESCRIPTION
## Problem

Two pinned packages have been dropped from the Debian 13 mirror, so builds
fail at the `apt-get install` step with exit code 100:

```
E: Version '17.9-0+deb13u1' for 'libpq5' was not found
E: Version '1.26.3-3+deb13u2' for 'nginx' was not found
```

Example: the `Build amd64` job on #424 ([run](https://github.com/hassio-addons/app-vaultwarden/actions/runs/30132651414/job/89610256220)),
which fails for this reason rather than anything to do with the Vaultwarden
bump it carries.

## Change

Bumps both to the versions currently published for trixie:

```
libpq5   17.9-0+deb13u1     ->  17.10-0+deb13u1
nginx    1.26.3-3+deb13u2   ->  1.26.3-3+deb13u7
```

## Relationship to the open Renovate PRs

- **#419** bumps `nginx` to `1.26.3-3+deb13u7` — same value as here, but on its
  own it still won't build, because `libpq5` is also stale. Happy to drop the
  nginx hunk and rebase on #419 if you'd rather keep the bot's PR as the source
  of truth for that one.
- **#424** (Vaultwarden 1.37.0) is blocked purely by this; it should go green
  once this lands.

Nothing upstream currently bumps `libpq5`.

## Verification

Built against `ghcr.io/hassio-addons/debian-base:9.3.0`:

- `linux/amd64` — pass
- `linux/arm64` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled Nginx and PostgreSQL client packages to newer maintenance versions.
  * Includes the latest available security and stability updates for these components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->