### PR TITLE
fix: bump to Vaultwarden 1.37.1 and fix stale Debian pins so the build passes

### DIFF
--- a/vaultwarden/Dockerfile
+++ b/vaultwarden/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:9.3.0
 ###############################################################################
 # Get prebuilt containers from Vaultwarden
 ###############################################################################
-FROM "vaultwarden/server:1.36.0" AS vaultwarden
+FROM "vaultwarden/server:1.37.1" AS vaultwarden
 
 ###############################################################################
 # Build the actual app.
@@ -24,8 +24,8 @@ RUN \
     \
     && apt-get install -y --no-install-recommends \
         libmariadb-dev-compat=1:11.8.6-0+deb13u1 \
-        libpq5=17.9-0+deb13u1 \
-        nginx=1.26.3-3+deb13u2 \
+        libpq5=17.10-0+deb13u1 \
+        nginx=1.26.3-3+deb13u7 \
         sqlite3=3.46.1-7+deb13u1 \
     && apt-get clean \
     && rm -f -r \


### PR DESCRIPTION
## Summary
Combines two already-open, non-conflicting fixes so the build actually passes:

- The Docker tag bump from #424 (`vaultwarden/server` `1.36.0` → `1.37.1`)
- The Debian package pin fix from #430 (`libpq5`, `nginx`)

Neither PR builds on its own currently: #424's CI fails on `Build amd64`/`Build aarch64` because the pinned `libpq5`/`nginx` versions in the Dockerfile no longer exist in the Debian 13 (trixie) repo — this is unrelated to the vaultwarden version itself, so bumping the tag alone doesn't fix it. #430 fixes the pins but isn't rebased on top of the version bump.

Relates to #425 (upstream Vaultwarden 1.37.0 contains fixes for several medium-severity vulnerabilities: SSRF, cross-organization access, DDoS).

## Changes
```
-FROM "vaultwarden/server:1.36.0" AS vaultwarden
+FROM "vaultwarden/server:1.37.1" AS vaultwarden

-        libpq5=17.9-0+deb13u1 \
-        nginx=1.26.3-3+deb13u2 \
+        libpq5=17.10-0+deb13u1 \
+        nginx=1.26.3-3+deb13u7 \
```

## Test plan
- [x] Verified via packages.debian.org that `libpq5=17.10-0+deb13u1` and `nginx=1.26.3-3+deb13u7` are the currently available trixie package versions
- [x] Confirmed #424's CI build failure log points exactly at the stale `libpq5`/`nginx` apt pins (`E: Version '...' for 'libpq5' was not found`), not at the vaultwarden tag change
- [ ] CI on this PR (amd64/aarch64 build)

cc @frenck — happy to close this in favor of whichever of #424/#430 you'd rather land the combined change on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Vaultwarden base image to version 1.37.1.
  * Refreshed bundled Debian package versions for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->