### PR TITLE
⬆️ Update vaultwarden/server Docker tag to v1.37.1

### DIFF
--- a/vaultwarden/Dockerfile
+++ b/vaultwarden/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:9.3.0
 ###############################################################################
 # Get prebuilt containers from Vaultwarden
 ###############################################################################
-FROM "vaultwarden/server:1.36.0" AS vaultwarden
+FROM "vaultwarden/server:1.37.1" AS vaultwarden
 
 ###############################################################################
 # Build the actual app.
@@ -24,8 +24,8 @@ RUN \
     \
     && apt-get install -y --no-install-recommends \
         libmariadb-dev-compat=1:11.8.6-0+deb13u1 \
-        libpq5=17.9-0+deb13u1 \
-        nginx=1.26.3-3+deb13u2 \
+        libpq5=17.10-0+deb13u1 \
+        nginx=1.26.3-3+deb13u7 \
         sqlite3=3.46.1-7+deb13u1 \
     && apt-get clean \
     && rm -f -r \


### PR DESCRIPTION
# Proposed Changes

Bumps the bundled Vaultwarden server from `1.36.0` to the current upstream release `1.37.1`, and refreshes the two stale Debian 13 (trixie) apt pins that block the image build.

```diff
-FROM "vaultwarden/server:1.36.0" AS vaultwarden
+FROM "vaultwarden/server:1.37.1" AS vaultwarden

-        libpq5=17.9-0+deb13u1 \
-        nginx=1.26.3-3+deb13u2 \
+        libpq5=17.10-0+deb13u1 \
+        nginx=1.26.3-3+deb13u7 \
```

**Rationale**

- Vaultwarden `1.37.0`+ is **required** for Bitwarden clients `2026.7.0` and newer; the current addon (`1.36.0`) breaks against them. This is the root cause behind the recent wave of "vault is blank / no access since the update" reports (#437, #434).
- `1.37.0` also ships fixes for several medium-severity security advisories (icon-endpoint SSRF, cross-organization cipher access, unauthenticated WebSocket DDoS, and others).
- `1.37.1` resolves the invite regression introduced in `1.37.0`.

**Why the pins are refreshed in the same change**

A tag bump on its own no longer builds: the pinned `libpq5=17.9-0+deb13u1` and `nginx=1.26.3-3+deb13u2` versions have been superseded in the trixie repo and now 404 during `apt-get install`, failing the `Build amd64` / `Build aarch64` jobs (this is what #424 hits). Bumping to the current `17.10-0+deb13u1` / `1.26.3-3+deb13u7` restores a passing build. The other two pins (`libmariadb-dev-compat`, `sqlite3`) were checked and are still current.

Verified against packages.debian.org/trixie that the new pin versions are the ones currently served, and that the old versions no longer resolve.

**Why this is opened manually rather than left to Renovate**

Renovate could not land this on its own, so the two halves have to be combined by hand:

1. Renovate **did** open the tag bump (#424) and is configured to auto-merge `vaultwarden/server` minor/patch updates — but auto-merge only fires on green CI, and #424's build fails on the stale `libpq5`/`nginx` pins in the same Dockerfile. Renovate only rewrites the `FROM` line it manages; it has no awareness that the neighbouring apt pins have gone stale, so its own PR can never pass its own gate.
2. Renovate **cannot** open the `libpq5` bump at all: its repology datasource lookup is failing (`Failed to look up repology package debian_13/postgresql-13: no-result`, per the Dependency Dashboard #252), so it never sees that `libpq5` needs updating.

Because the version bump and the pin refresh must travel together to produce a buildable image, and Renovate's per-dependency model plus the broken lookup prevent it from producing that combination, this is submitted as a single manual PR.

## Related Issues

- Closes #425 (update to 1.37)
- Closes #437 (Android client `2026.7.x` — no vault access since the client update)
- Closes #434 (browser extension `2026.7.0` — vault renders blank)

Supersedes #424 (tag-only, failing CI) and #430 (pins-only); overlaps #433. Happy to close in favour of whichever the maintainers prefer to land.

(Not #432 — that's a web-UI/ingress access problem, unrelated to the server version.)
