### PR TITLE
Fix Repology mapping for the libpq5 apt pin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
       ],
       "versioningTemplate": "deb",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "debian_13/{{{replace 'libpq5' 'postgresql-13' package}}}"
+      "depNameTemplate": "debian_13/{{{package}}}"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
# Proposed Changes

The custom manager that keeps the apt pins in `vaultwarden/Dockerfile` current maps `libpq5` onto `debian_13/postgresql-13`:

```json
"depNameTemplate": "debian_13/{{{replace 'libpq5' 'postgresql-13' package}}}"
```

Debian 13 ships PostgreSQL **17**, so that project does not exist in Repology. The lookup returns no result and Renovate has never proposed an update for that pin — which is how it drifted to `17.9-0+deb13u1`, a version no longer in the archive, and started failing every image build.

Renovate has been reporting this itself on the Dependency Dashboard (#252) the whole time:

> ⚠️ Renovate failed to look up the following dependencies: `Failed to look up repology package debian_13/postgresql-13: no-result`.
>
> Files affected: `vaultwarden/Dockerfile`

```diff
-      "depNameTemplate": "debian_13/{{{replace 'libpq5' 'postgresql-13' package}}}"
+      "depNameTemplate": "debian_13/{{{package}}}"
```

**Why drop the `replace` rather than retarget it at `postgresql-17`**

Renovate's Repology datasource resolves `binname` before `srcname`, so `debian_13/libpq5` resolves directly — no mapping is needed at all. Retargeting to `postgresql-17` also works today but breaks again at the next Debian release, which is exactly how the current bug was introduced: #396 moved the base image to Debian 13 and updated the `debian_12/` prefix to `debian_13/`, but left `postgresql-13` in place.

**Verification**

Queried against the same endpoint the Repology datasource uses (`/tools/project-by?repo=debian_13&name_type=binname`). All four pinned packages resolve:

| package | pinned today | resolves to |
| --- | --- | --- |
| `libmariadb-dev-compat` | `1:11.8.6-0+deb13u1` | `1:11.8.6-0+deb13u1` (current) |
| `libpq5` | `17.9-0+deb13u1` | `17.11-0+deb13u1` |
| `nginx` | `1.26.3-3+deb13u2` | `1.26.3-3+deb13u7` |
| `sqlite3` | `3.46.1-7+deb13u1` | `3.46.1-7+deb13u1` (current) |

`renovate-config-validator` passes on the result.

**Scope — this does not fix the build**

This is the prevention half, not the repair. It does not touch the Dockerfile and will not turn CI green on its own; #433 / #438 restore the build by advancing the two stale pins. What this changes is that `libpq5` stops being invisible to Renovate, so the pin cannot silently rot again.

The two are complementary and can land in either order. Once the pins are current and this is merged, Renovate proposes `libpq5` updates like it already does for `nginx` and `sqlite3`, and the existing `automerge: true` on the `repology` datasource keeps them flowing without manual intervention.

**Note on CI**

The `Build amd64` / `Build aarch64` jobs fail on this branch for the same pre-existing reason they fail on every open PR — the stale pins inherited from `main`. A change confined to `.github/renovate.json` cannot affect a Docker build. The `PR Labels` check also fails until someone with triage applies one of the required labels (`bugfix` or `ci` would fit); that needs write/triage access I do not have.

## Related Issues

- #427 — same diagnosis, filed 2026-07-27 and self-closed by the author as a duplicate of #425. The mapping bug is not actually covered in #425, so the analysis is preserved here.
- #428 — prior art for this fix, by @JaSha256, withdrawn by its author. Same one-line change, retargeted at `postgresql-17`; this supersedes it with the version-independent form. Credit for the original diagnosis is theirs.
- #252 — Renovate Dependency Dashboard, carrying the lookup failure.
- #419 — `nginx` pin bump, open since May and unable to automerge because the `libpq5` pin has never been resolvable.
- #424 — Renovate's own 1.37.1 bump, red on `Build amd64` / `Build aarch64` since July for the same reason: it rewrites only the `FROM` line it manages and inherits the stale apt pins sitting beside it, so its own `automerge: true` can never fire on its own PR.
- #425, #433, #438 — the user-facing breakage and the 1.37.1 bump this unblocks going forward.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency tracking for Repology packages on Debian 13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
