### PR TITLE
Track Debian apt pins with the Renovate deb datasource

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,8 +25,8 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
       ],
       "versioningTemplate": "deb",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "debian_13/{{{package}}}"
+      "datasourceTemplate": "deb",
+      "depNameTemplate": "{{{package}}}"
     },
     {
       "customType": "regex",
@@ -39,7 +39,12 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["deb"],
+      "registryUrls": [
+        "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian?suite=trixie-updates&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian-security?suite=trixie-security&components=main&binaryArch=amd64"
+      ],
       "automerge": true
     },
     {


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Repology has become unreliable as a datasource lately: throttling, timeouts, and missing packages. It also forces us to map binary package names onto source package names, which is exactly what went wrong with the `libpq5` pin in #440.

Renovate ships a native [`deb` datasource](https://docs.renovatebot.com/modules/datasource/deb/) that reads the Debian package indices directly, so this switches the apt pins over to it. It indexes **binary** package names, which means `depNameTemplate` becomes plain `{{{package}}}` and the whole name mapping problem disappears.

The registry URLs are a one to one mirror of the apt sources in `ghcr.io/hassio-addons/debian-base:9.4.0`:

| Source | Suite | Component |
| --- | --- | --- |
| `deb.debian.org/debian` | `trixie` | `main` |
| `deb.debian.org/debian` | `trixie-updates` | `main` |
| `deb.debian.org/debian-security` | `trixie-security` | `main` |

The `deb` datasource uses a `merge` registry strategy, so releases from all three are aggregated rather than first one wins.

### Known limitation

The datasource currently hardcodes `Packages.gz`, but `trixie-updates` and `trixie-security` serve only `Packages.xz`. (Their `InRelease` files also list an uncompressed `Packages`, but the archive does not actually serve that file: it 404s, on every suite, including plain `trixie`. The checksum is listed so that apt can verify the index after decompressing it.) Those two suites are therefore inert for now. This fails gracefully: lookups are caught and skipped per component, so `trixie` `main` keeps working, and the other two start working by themselves once renovatebot/renovate#44330 is resolved. They are kept in the config so it stays a truthful description of what the image actually pulls from.

The practical impact is limited to `libpq5`, which is pinned at `17.11-0+deb13u1` from `trixie-security` while `main` currently carries `17.10-0+deb13u1`. It will need a manual bump until the next point release folds it into `main`. The pins for `libmariadb-dev-compat`, `nginx`, and `sqlite3` all resolve from `main` and update as normal.

Validated with `renovate-config-validator` from Renovate 44.33.2.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follow up on #440, which worked around the Repology name mapping for `libpq5`.

Upstream: renovatebot/renovate#44330

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Debian package update configuration to use the Debian datasource.
  * Restricted package lookups to the Debian Trixie, updates, and security repositories for amd64.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
